### PR TITLE
Fix: could not turn off uniformity enforcement

### DIFF
--- a/brisk/include/brisk/scale-space-feature-detector.h
+++ b/brisk/include/brisk/scale-space-feature-detector.h
@@ -111,9 +111,10 @@ class ScaleSpaceFeatureDetector {
       scaleSpaceLayers[i].SetMaxNumKpt(_maxNumKpt);
       scaleSpaceLayers[i].SetAbsoluteThreshold(_absoluteThreshold);
     }
+    bool enforceUniformity = _uniformityRadius > 0.0;
     for (size_t i = 0; i < scaleSpaceLayers.size(); ++i) {
       // Only do refinement, if no keypoints are passed.
-      scaleSpaceLayers[i].DetectScaleSpaceMaxima(keypoints, true,
+      scaleSpaceLayers[i].DetectScaleSpaceMaxima(keypoints, enforceUniformity,
                                                  !usePassedKeypoints,
                                                  usePassedKeypoints);
     }


### PR DESCRIPTION
When I tried to turn off the uniformity constraint, I noticed that it is always enforced even if I set the radius to 0. 

[Here](https://github.com/ethz-asl/ethzasl_brisk/blob/master/brisk/include/brisk/scale-space-feature-detector.h#L110) the uniformity radius is set for all scale space layers. However [the setter sets the radius to 1.0 if it is equal to 0.0](https://github.com/ethz-asl/ethzasl_brisk/blob/master/brisk/include/brisk/internal/scale-space-layer-inl.h#L186). That's why even if you want to to turn off the uniformity constraint by setting it to 0.0, it passes [this  > 0.0 check](https://github.com/ethz-asl/ethzasl_brisk/blob/master/brisk/include/brisk/internal/scale-space-layer-inl.h#L370) and is called with radius = 1.0.

This doesn't make a lot of sense to me. I fixed it by turning off the uniformity constraint flag on the detector level if the radius is  <= 0.0 [See below](https://github.com/ethz-asl/ethzasl_brisk/compare/fix/turn_off_uniformity_constraint?expand=1#diff-304e53f216e7915e8c87bb98a25e76b8R114)

This is an example for feature matches with uniformity radius = 0.0 (prior to this fix):
![brisk_matches_12325221000 5point](https://cloud.githubusercontent.com/assets/5071588/7389942/480353dc-ee73-11e4-889a-5aa0673021af.png)

These are the same two images with feature matches with uniformity radius = 0.0 (after the fix):
![brisk_matches_12325221000 5point](https://cloud.githubusercontent.com/assets/5071588/7389938/40880742-ee73-11e4-85a8-e2b4b83eef46.png)

@simonlynen do you think this is a valid bug/fix?
