### PR TITLE
Enforce keypoint number limit

### DIFF
--- a/brisk/include/brisk/internal/scale-space-layer-inl.h
+++ b/brisk/include/brisk/internal/scale-space-layer-inl.h
@@ -373,7 +373,7 @@ void ScaleSpaceLayer<SCORE_CALCULATOR_T>::DetectScaleSpaceMaxima(
   }else{
     // If no uniformity constraint is enforced, we need to limit the number of keypoints.
     if(points.size() > _maxNumKpt){
-      std::sort(points.begin(), points.end());
+      std::partial_sort(points.begin(), points.begin() + _maxNumKpt, points.end());
       points.resize(_maxNumKpt);
     }
   }


### PR DESCRIPTION
If the uniformity constraint is turned off, there is no limit on how many keypoints the detector outputs. The parameter max_number_of_keypoints is ignored. This fix makes the detector return the max_number_of_keypoints keypoints with the best score.
