### PR TITLE
Bump version of agast to match other brisk packages

### DIFF
--- a/agast/package.xml
+++ b/agast/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>agast</name>
-  <version>0.0.0</version>
+  <version>2.0.0</version>
   <description>The agast package</description>
 
   <maintainer email="slynen@ethz.ch">Simon Lynen</maintainer>
@@ -12,7 +12,7 @@
   <depend>glog_catkin</depend>
   <depend>opencv3_catkin</depend>
   <depend>roscpp</depend>
-    
+
   <buildtool_depend>catkin</buildtool_depend>
   <buildtool_depend>catkin_simple</buildtool_depend>
 </package>


### PR DESCRIPTION
Bloom requires all packages in a repo to have the same version.