### PR TITLE
Added missing include (functional)

### DIFF
--- a/brisk/src/brisk-feature-detector.cc
+++ b/brisk/src/brisk-feature-detector.cc
@@ -39,6 +39,7 @@
  */
 
 #include <algorithm>
+#include <functional>
 
 #include <agast/glog.h>
 #include <agast/wrap-opencv.h>


### PR DESCRIPTION
18.04: 
```
/ethzasl_brisk/brisk/src/brisk-feature-detector.cc: In function ‘void {anonymous}::RemoveInvalidKeyPoints(const cv::Mat&, std::vector<cv::KeyPoint>*)’:
/ethzasl_brisk/brisk/src/brisk-feature-detector.cc:55:8: error: ‘function’ is not a member of ‘std’
   std::function<bool(const agast::KeyPoint& key_pt)> masking =
        ^~~~~~~~
/ethzasl_brisk/brisk/src/brisk-feature-detector.cc:55:8: note: suggested alternative: ‘is_function’
   std::function<bool(const agast::KeyPoint& key_pt)> masking =
        ^~~~~~~~
        is_function
/ethzasl_brisk/brisk/src/brisk-feature-detector.cc:55:17: error: expected primary-expression before ‘bool’
   std::function<bool(const agast::KeyPoint& key_pt)> masking =
                 ^~~~
/ethzasl_brisk/brisk/src/brisk-feature-detector.cc:65:22: error: ‘masking’ was not declared in this scope
                      masking), keypoints->end());
                      ^~~~~~~
/ethzasl_brisk/brisk/src/brisk-feature-detector.cc:65:22: note: suggested alternative: ‘mask’
                      masking), keypoints->end());
                      ^~~~~~~
                      mask
```
